### PR TITLE
Add indent_size to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
... so the code would look nicer on Github

Before:

```
class PostcsssortingCommand(sublime_plugin.TextCommand):
        def run(self, edit):
                if not self.has_selection():
                        region = sublime.Region(0, self.view.size())
                        originalBuffer = self.view.substr(region)
                        processed = self.sorting(originalBuffer)
```

After:

```
class PostcsssortingCommand(sublime_plugin.TextCommand):
    def run(self, edit):
        if not self.has_selection():
            region = sublime.Region(0, self.view.size())
            originalBuffer = self.view.substr(region)
            processed = self.sorting(originalBuffer)
```
