### PR TITLE
Project-specific config

### DIFF
--- a/PostCSSSorting.py
+++ b/PostCSSSorting.py
@@ -15,17 +15,18 @@ sublime.Region.totuple = lambda self: (self.a, self.b)
 sublime.Region.__iter__ = lambda self: self.totuple().__iter__()
 
 BIN_PATH = join(sublime.packages_path(), dirname(realpath(__file__)), 'sorting.js')
-CONFIG_NAME = '.postcss-sorting.json'
+CONFIG_NAMES = ['.postcss-sorting.json', 'postcss-sorting.json']
 
 def get_setting(view, key):
 	setting = None
 	local_config = None
 
 	for folder in sublime.active_window().project_data()['folders']:
-		config_file = join(folder['path'], CONFIG_NAME)
-		if path.isfile(config_file):
-			with open(config_file) as data_file:
-				local_config = json.load(data_file)
+		for config_name in CONFIG_NAMES:
+			config_file = join(folder['path'], config_name)
+			if path.isfile(config_file):
+				with open(config_file) as data_file:
+					local_config = json.load(data_file)
 
 	if (local_config):
 		setting = local_config.get(key)

--- a/PostCSSSorting.py
+++ b/PostCSSSorting.py
@@ -14,14 +14,20 @@ sublime.Region.totuple = lambda self: (self.a, self.b)
 sublime.Region.__iter__ = lambda self: self.totuple().__iter__()
 
 BIN_PATH = join(sublime.packages_path(), dirname(realpath(__file__)), 'sorting.js')
+CONFIG_NAME = '.postcss-sorting.json'
 
 def get_setting(view, key):
-	settings = view.settings().get('PostCSSSorting')
+	setting = local_config.get(key)
 
-	if settings is None:
-		settings = sublime.load_settings('PostCSSSorting.sublime-settings')
+	if setting is None:
+		settings = view.settings().get('PostCSSSorting')
 
-	return settings.get(key)
+		if settings is None:
+			settings = sublime.load_settings('PostCSSSorting.sublime-settings')
+
+		setting = settings.get(key)
+
+	return setting
 
 def is_supported_syntax(view):
 	syntax = splitext(basename(view.settings().get('syntax')))[0]
@@ -30,6 +36,11 @@ def is_supported_syntax(view):
 
 class PostcsssortingCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
+		for folder in sublime.active_window().project_data()['folders']:
+			config_file = join(folder['path'], CONFIG_NAME)
+			with open(config_file) as data_file:
+				local_config = json.load(data_file)
+
 		if not self.has_selection():
 			region = sublime.Region(0, self.view.size())
 			originalBuffer = self.view.substr(region)

--- a/PostCSSSorting.py
+++ b/PostCSSSorting.py
@@ -3,6 +3,7 @@ import sublime_plugin
 import json
 from os.path import dirname, realpath, join, basename, splitext
 from os import path
+from pprint import pprint
 
 try:
 	# Python 2
@@ -17,27 +18,32 @@ sublime.Region.__iter__ = lambda self: self.totuple().__iter__()
 BIN_PATH = join(sublime.packages_path(), dirname(realpath(__file__)), 'sorting.js')
 CONFIG_NAMES = ['.postcss-sorting.json', 'postcss-sorting.json']
 
-def get_setting(view, key):
-	setting = None
-	local_config = None
-
+def local_postcss_settings():
 	for folder in sublime.active_window().project_data()['folders']:
 		for config_name in CONFIG_NAMES:
 			config_file = join(folder['path'], config_name)
 			if path.isfile(config_file):
 				with open(config_file) as data_file:
-					local_config = json.load(data_file)
+					return json.load(data_file)
 
-	if (local_config):
-		setting = local_config.get(key)
+	return {}
+
+def sublime_project_settings(view):
+	settings = view.settings().get('PostCSSSorting')
+
+	if settings is None:
+		settings = {}
+
+	return settings
+
+def get_setting(view, key):
+	setting = local_postcss_settings().get(key)
 
 	if setting is None:
-		settings = view.settings().get('PostCSSSorting')
+		setting = sublime_project_settings(view).get(key)
 
-		if settings is None:
-			settings = sublime.load_settings('PostCSSSorting.sublime-settings')
-
-		setting = settings.get(key)
+	if setting is None:
+		setting = sublime.load_settings('PostCSSSorting.sublime-settings').get(key)
 
 	return setting
 

--- a/PostCSSSorting.py
+++ b/PostCSSSorting.py
@@ -2,6 +2,8 @@ import sublime
 import sublime_plugin
 import json
 from os.path import dirname, realpath, join, basename, splitext
+from os import path
+from pprint import pprint
 
 try:
 	# Python 2
@@ -17,7 +19,17 @@ BIN_PATH = join(sublime.packages_path(), dirname(realpath(__file__)), 'sorting.j
 CONFIG_NAME = '.postcss-sorting.json'
 
 def get_setting(view, key):
-	setting = local_config.get(key)
+	setting = None
+	local_config = None
+
+	for folder in sublime.active_window().project_data()['folders']:
+		config_file = join(folder['path'], CONFIG_NAME)
+		if path.isfile(config_file):
+			with open(config_file) as data_file:
+				local_config = json.load(data_file)
+
+	if (local_config):
+		setting = local_config.get(key)
 
 	if setting is None:
 		settings = view.settings().get('PostCSSSorting')
@@ -36,11 +48,6 @@ def is_supported_syntax(view):
 
 class PostcsssortingCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
-		for folder in sublime.active_window().project_data()['folders']:
-			config_file = join(folder['path'], CONFIG_NAME)
-			with open(config_file) as data_file:
-				local_config = json.load(data_file)
-
 		if not self.has_selection():
 			region = sublime.Region(0, self.view.size())
 			originalBuffer = self.view.substr(region)

--- a/PostCSSSorting.py
+++ b/PostCSSSorting.py
@@ -3,7 +3,6 @@ import sublime_plugin
 import json
 from os.path import dirname, realpath, join, basename, splitext
 from os import path
-from pprint import pprint
 
 try:
 	# Python 2


### PR DESCRIPTION
Hello!

I am new to sublime packages, python and public pull request. So please correct me if I did something wrong.

### Problem
I am using `postcss-sorting` and `sublime-postcss-sorting` to keep my styles in nice shape. Recently my team started to use this tools too. But we have an annoying problem with sharing our configs.

For now, there are two ways to configure this plugin: you can use global configuration and `.sublime-project`. First one is obviously doesn't fit for us. The problem with second is that not everybody in our team using Sublime. 

### Solution
Use editor-agnostic configuration file. Both [atom-postcss-sorting](https://github.com/lysyi3m/atom-postcss-sorting) and [vscode-postcss-sorting](https://github.com/mrmlnc/vscode-postcss-sorting) make use of `.postcss-sorting.json` and `postcss-sorting.json` files and `postcssSortingConfig` section of `package.json`. So I thought it woud be a good idea to teach sublime-postcss-sorting do the same.

### Implementation
I am new to this, so before implementing all of the features I tried to make a basic lookup for `.postcss-sorting.json` and parse it. Am I heading in the right direction? :)